### PR TITLE
docs: add archival announcement to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # idekube container
 
+> [!IMPORTANT]
+> **This repository is archived.** Development and maintenance have moved to [**idekube-project/idekube-container**](https://github.com/idekube-project/idekube-container). Please refer to the new repository for the latest updates, releases, and issue tracking.
+
 <div style="text-align: center;">
     <img src="assets/screenshot-0.jpg" alt="Screenshot" style="width: 100%; max-width: 100%; height: auto;">
 </div>


### PR DESCRIPTION
Notify users that this repository is archived and that maintenance
continues at idekube-project/idekube-container.